### PR TITLE
Correct output of projection matrix and mean vec

### DIFF
--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -471,15 +471,15 @@ int run(int argc, const char** argv)
 	{
 		output.embedding.transposeInPlace();
 	}
-	write_data(&output.embedding, ofs, delimiter[0]);
+	write_matrix(&output.embedding, ofs, delimiter[0]);
 	ofs.close();
 
 	if (output_projection && output.projection.implementation)
 	{
 		tapkee::MatrixProjectionImplementation* matrix_projection =
 			dynamic_cast<tapkee::MatrixProjectionImplementation*>(output.projection.implementation);
-		write_data(&matrix_projection->proj_mat, ofs_matrix, delimiter[0]);
-		write_data(&matrix_projection->mean_vec, ofs_mean, delimiter[1]);
+		write_matrix(&matrix_projection->proj_mat, ofs_matrix, delimiter[0]);
+		write_vector(&matrix_projection->mean_vec, ofs_mean);
 	}
 	output.projection.clear();
 	ofs_matrix.close();

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -391,7 +391,7 @@ int run(int argc, const char** argv)
 	ifstream ifs(input_filename.c_str());
 	ofstream ofs(output_filename.c_str());
 	ofstream ofs_matrix(output_matrix_filename.c_str());
-	ofstream ofs_mean(output_matrix_filename.c_str());
+	ofstream ofs_mean(output_mean_filename.c_str());
 
 	std::string delimiter = ",";
 	if (opt.isSet(OPT_LONG_PREFIX DELIMITER_KEYWORD))
@@ -471,13 +471,15 @@ int run(int argc, const char** argv)
 	{
 		output.embedding.transposeInPlace();
 	}
-	write_data(output.embedding, ofs, delimiter[0]);
+	write_data(&output.embedding, ofs, delimiter[0]);
 	ofs.close();
 
-	if (output_projection && output.projection.implementation) 
+	if (output_projection && output.projection.implementation)
 	{
-		ofs_matrix << ((tapkee::MatrixProjectionImplementation*)output.projection.implementation)->proj_mat;
-		ofs_mean << ((tapkee::MatrixProjectionImplementation*)output.projection.implementation)->mean_vec;
+		tapkee::MatrixProjectionImplementation* matrix_projection =
+			dynamic_cast<tapkee::MatrixProjectionImplementation*>(output.projection.implementation);
+		write_data(&matrix_projection->proj_mat, ofs_matrix, delimiter[0]);
+		write_data(&matrix_projection->mean_vec, ofs_mean, delimiter[1]);
 	}
 	output.projection.clear();
 	ofs_matrix.close();

--- a/src/cli/util.hpp
+++ b/src/cli/util.hpp
@@ -72,7 +72,7 @@ tapkee::DenseMatrix read_data(ifstream& ifs, char delimiter)
 	}
 }
 
-void write_data(tapkee::DenseMatrix* matrix, ofstream& of, char delimiter)
+void write_matrix(tapkee::DenseMatrix* matrix, ofstream& of, char delimiter)
 {
 	for (int i=0; i<matrix->rows(); i++)
 	{
@@ -86,7 +86,7 @@ void write_data(tapkee::DenseMatrix* matrix, ofstream& of, char delimiter)
 	}
 }
 
-void write_data(tapkee::DenseVector* matrix, ofstream& of, char /*delimiter*/)
+void write_vector(tapkee::DenseVector* matrix, ofstream& of)
 {
 	for (int i=0; i<matrix->rows(); i++)
 	{

--- a/src/cli/util.hpp
+++ b/src/cli/util.hpp
@@ -72,17 +72,25 @@ tapkee::DenseMatrix read_data(ifstream& ifs, char delimiter)
 	}
 }
 
-void write_data(tapkee::DenseMatrix& matrix, ofstream& of, char delimiter)
+void write_data(tapkee::DenseMatrix* matrix, ofstream& of, char delimiter)
 {
-	for (int i=0; i<matrix.rows(); i++)
+	for (int i=0; i<matrix->rows(); i++)
 	{
-		for (int j=0; j<matrix.cols(); j++)
+		for (int j=0; j<matrix->cols(); j++)
 		{
-			of << matrix(i,j);
-			if (j!=matrix.cols()-1)
+			of << (*matrix)(i,j);
+			if (j!=matrix->cols()-1)
 				of << delimiter;
 		}
 		of << endl;
+	}
+}
+
+void write_data(tapkee::DenseVector* matrix, ofstream& of, char /*delimiter*/)
+{
+	for (int i=0; i<matrix->rows(); i++)
+	{
+		of << (*matrix)(i) << endl;
 	}
 }
 


### PR DESCRIPTION
- Use correct filepath for mean vector output
- Respect custom delimiters
- Utilize pointer semantics for explicit no-copy behaviour