### PR TITLE
corrected diffusion maps implementation

### DIFF
--- a/doc/methods/dm.markdown
+++ b/doc/methods/dm.markdown
@@ -11,15 +11,17 @@ feature vectors $ x\_1, \dots, x\_N $:
  
 * Transform the matrix $ K $ using the following equations
   $$ K\_{i,j} \leftarrow \frac{K\_{i,j}}{(p\_i p\_j)^q},$$ where $ p\_i = \sum\_{j=1}^{N} K\_{j,i}$. 
+  Only $ q=1 $ for 'standard' diffusion map is currently supported.
   Then, recompute $ p\_i = \sum\_{j=1}^{N} K\_{j,i} $ again and do
   $$ K\_{i,j} \leftarrow \frac{K\_{i,j}}{\sqrt{p\_i p\_j}}.$$
   
-* Construct embedding with $ \dim = t $ from the solution of the following partial eigenproblem
-  $$ K^{T} K f = \lambda f $$
-  for $t $ largest eigenvalues. Form the embedding matrix such that 
+* Construct embedding with $ \dim = d $ from the solution of the following partial eigenproblem
+  $$ K f = \lambda f $$
+  for $d+1 $ largest eigenvalues. Form the embedding matrix such that the 
   $i$-th coordinate ($ i=1,\dots,N $) of $j$-th largest
-  eigenvector ($ j=1,\dots,t$ ) corresponds to $j$-th coordinate 
-  of projected $i$-th vector.
+  eigenvector ($ j=2,\dots,d+1$ ) corresponds to $j$-th coordinate 
+  of projected $i$-th vector, normalized by $\lambda_i^t$ and the first eigenvector 
+  corresponding to $\lambda_1 = 1$.
 
 References
 ----------

--- a/include/tapkee/routines/diffusion_maps.hpp
+++ b/include/tapkee/routines/diffusion_maps.hpp
@@ -34,7 +34,7 @@ namespace tapkee_internal
 //!
 template <class RandomAccessIterator, class DistanceCallback>
 DenseSymmetricMatrix compute_diffusion_matrix(RandomAccessIterator begin, RandomAccessIterator end, DistanceCallback callback, 
-                                              const IndexType timesteps, const ScalarType width)
+                                              const ScalarType width)
 {
 	timed_context context("Diffusion map matrix computation");
 
@@ -64,9 +64,10 @@ DenseSymmetricMatrix compute_diffusion_matrix(RandomAccessIterator begin, Random
 	p = diffusion_matrix.colwise().sum();
 
 	// compute full matrix as we need to compute sum later
+	// TODO add weighting alpha, use linear algebra to compute D^-alpha K D^-alpha
 	for (IndexType i=0; i<n_vectors; i++)
 		for (IndexType j=0; j<n_vectors; j++)
-			diffusion_matrix(i,j) /= pow(p(i)*p(j),timesteps);
+			diffusion_matrix(i,j) /= p(i)*p(j);
 
 	// compute sqrt of column sum vector
 	p = diffusion_matrix.colwise().sum().cwiseSqrt();

--- a/include/tapkee/routines/diffusion_maps.hpp
+++ b/include/tapkee/routines/diffusion_maps.hpp
@@ -21,9 +21,9 @@ namespace tapkee_internal
 //! <ol>
 //! <li> Compute matrix \f$ K \f$ such as \f$ K_{i,j} = \exp\left(-\frac{d(x_i,x_j)^2}{w}\right) \f$.
 //! <li> Compute sum vector \f$ p = \sum_i K_{i,j}\f$.
-//! <li> Modify \f$ K \f$ with \f$ K_{i,j} = K_{i,j} / (p_i  p_j)^t \f$.
+//! <li> Modify \f$ K \f$ with \f$ K_{i,j} = K_{i,j} / (p_i  p_j)^\alpha \f$.
 //! <li> Compute sum vector \f$ p = \sum_i K_{i,j}\f$ again.
-//! <li> Normalize \f$ K \f$ with \f$ K_{i,j} = K_{i,j} / (p_i p_j) \f$.
+//! <li> Normalize \f$ K \f$ with \f$ K_{i,j} = K_{i,j} / \sqrt(p_i p_j) \f$.
 //! </ol>
 //!
 //! @param begin begin data iterator


### PR DESCRIPTION
The existing dm implementation is wrong in several places. This fixes the implementation following the original paper by Coifman and Lafon. Currently only alpha=1 (in the notation from that paper) is supported in the corrected code.