### PR TITLE
OpenMP: Add missing shared variable specifications

### DIFF
--- a/include/tapkee/routines/diffusion_maps.hpp
+++ b/include/tapkee/routines/diffusion_maps.hpp
@@ -45,7 +45,7 @@ DenseSymmetricMatrix compute_diffusion_matrix(RandomAccessIterator begin, Random
 	RESTRICT_ALLOC;
 
 	// compute gaussian kernel matrix
-#pragma omp parallel shared(diffusion_matrix,begin,callback) default(none)
+#pragma omp parallel shared(diffusion_matrix,begin,callback,width,n_vectors) default(none)
 	{
 		IndexType i_index_iter, j_index_iter;
 #pragma omp for nowait

--- a/include/tapkee/routines/isomap.hpp
+++ b/include/tapkee/routines/isomap.hpp
@@ -50,7 +50,7 @@ DenseSymmetricMatrix compute_shortest_distances_matrix(RandomAccessIterator begi
 
 	DenseSymmetricMatrix shortest_distances(N,N);
 
-#pragma omp parallel shared(shortest_distances,neighbors,begin,callback) default(none)
+#pragma omp parallel shared(shortest_distances,neighbors,begin,callback,N,n_neighbors) default(none)
 	{
 		bool* f = new bool[N];
 		bool* s = new bool[N];
@@ -168,7 +168,8 @@ DenseMatrix compute_shortest_distances_matrix(RandomAccessIterator begin, Random
 
 	DenseMatrix shortest_distances(landmarks.size(),N);
 
-#pragma omp parallel shared(shortest_distances,begin,landmarks,neighbors,callback) default(none)
+#pragma omp parallel shared(shortest_distances,begin,landmarks,neighbors,callback, \
+		N,N_landmarks,n_neighbors) default(none)
 	{
 		bool* f = new bool[N];
 		bool* s = new bool[N];

--- a/include/tapkee/routines/locally_linear.hpp
+++ b/include/tapkee/routines/locally_linear.hpp
@@ -32,7 +32,8 @@ SparseWeightMatrix tangent_weight_matrix(RandomAccessIterator begin, RandomAcces
 	SparseTriplets sparse_triplets;
 	sparse_triplets.reserve((k*k+2*k+1)*(end-begin));
 
-#pragma omp parallel shared(begin,end,neighbors,callback,sparse_triplets) default(none)
+#pragma omp parallel shared(begin,end,neighbors,callback,sparse_triplets, \
+		target_dimension,shift,k) default(none)
 	{
 		IndexType index_iter;
 		DenseMatrix gram_matrix = DenseMatrix::Zero(k,k);
@@ -102,7 +103,7 @@ SparseWeightMatrix linear_weight_matrix(const RandomAccessIterator& begin, const
 	SparseTriplets sparse_triplets;
 	sparse_triplets.reserve((k*k+2*k+1)*(end-begin));
 
-#pragma omp parallel shared(begin,end,neighbors,callback,sparse_triplets) default(none)
+#pragma omp parallel shared(begin,end,neighbors,callback,sparse_triplets,k,trace_shift,shift) default(none)
 	{
 		IndexType index_iter;
 		DenseMatrix gram_matrix = DenseMatrix::Zero(k,k);
@@ -175,7 +176,8 @@ SparseWeightMatrix hessian_weight_matrix(RandomAccessIterator begin, RandomAcces
 
 	const IndexType dp = target_dimension*(target_dimension+1)/2;
 
-#pragma omp parallel shared(begin,end,neighbors,callback,sparse_triplets) default(none)
+#pragma omp parallel shared(begin,end,neighbors,callback,sparse_triplets, \
+		target_dimension,dp,k) default(none)
 	{
 		IndexType index_iter;
 		DenseMatrix gram_matrix = DenseMatrix::Zero(k,k);

--- a/include/tapkee/routines/multidimensional_scaling.hpp
+++ b/include/tapkee/routines/multidimensional_scaling.hpp
@@ -37,7 +37,7 @@ DenseSymmetricMatrix compute_distance_matrix(RandomAccessIterator begin, RandomA
 	const IndexType n_landmarks = landmarks.size();
 	DenseSymmetricMatrix distance_matrix(n_landmarks,n_landmarks);
 
-#pragma omp parallel shared(begin,landmarks,distance_matrix,callback) default(none)
+#pragma omp parallel shared(begin,landmarks,distance_matrix,callback,n_landmarks) default(none)
 	{
 		IndexType i_index_iter,j_index_iter;
 #pragma omp for nowait
@@ -80,7 +80,7 @@ DenseMatrix triangulate(RandomAccessIterator begin, RandomAccessIterator end, Pa
 		landmarks_embedding.first.col(i).array() /= landmarks_embedding.second(i);
 
 #pragma omp parallel shared(begin,end,to_process,distance_callback,landmarks, \
-		landmarks_embedding,landmark_distances_squared,embedding) default(none)
+		landmarks_embedding,landmark_distances_squared,embedding,n_vectors,n_landmarks) default(none)
 	{
 		DenseVector distances_to_landmarks(n_landmarks);
 		IndexType index_iter;
@@ -116,7 +116,7 @@ DenseSymmetricMatrix compute_distance_matrix(RandomAccessIterator begin, RandomA
 	const IndexType n_vectors = end-begin;
 	DenseSymmetricMatrix distance_matrix(n_vectors,n_vectors);
 
-#pragma omp parallel shared(begin,distance_matrix,callback) default(none)
+#pragma omp parallel shared(begin,distance_matrix,callback,n_vectors) default(none)
 	{
 		IndexType i_index_iter,j_index_iter;
 #pragma omp for nowait


### PR DESCRIPTION
Because of the strict default(none), all variables that are used within
parallel context need be specified.

Fixes compile errors with g++ (GCC) 9.1.0.