### PR TITLE
Fix Windows action

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        build_type: [Debug, Release]
+        build_type: [Release]
 
     steps:
     - uses: actions/checkout@v3

--- a/include/tapkee/neighbors/neighbors.hpp
+++ b/include/tapkee/neighbors/neighbors.hpp
@@ -162,7 +162,8 @@ Neighbors find_neighbors_vptree_impl(const RandomAccessIterator& begin, const Ra
     for (RandomAccessIterator i = begin; i != end; ++i)
     {
         LocalNeighbors local_neighbors = tree.search(i, k + 1);
-        std::remove(local_neighbors.begin(), local_neighbors.end(), i - begin);
+        auto it = std::remove(local_neighbors.begin(), local_neighbors.end(), i - begin);
+        local_neighbors.erase(it, local_neighbors.end());
         neighbors.push_back(local_neighbors);
     }
 


### PR DESCRIPTION
Although definitely not the ideal fix, still an improvement.

Windows Debug fails, causing the corresponding Release fail due to cancellation. When Debug is not run, then Release passes. 

Debug symbols were not found in the Debug eigendecomposition .exe.

