### PR TITLE
Fix missing refactoring in example.

### DIFF
--- a/examples/rna/rna.cpp
+++ b/examples/rna/rna.cpp
@@ -33,7 +33,7 @@ int main(int argc, const char **argv)
 
     MatchKernelCallback kernel;
 
-    TapkeeOutput result = .with((method = KernelLocallyLinearEmbedding, num_neighbors = 30))
+    TapkeeOutput result = with((method = KernelLocallyLinearEmbedding, num_neighbors = 30))
                               .withKernel(kernel)
                               .embedUsing(rnas);
 


### PR DESCRIPTION
I overlooked the check in examples before only grepping for initialize. I compiled the examples now, when running the rna, it run for a little bit and then got a std::bad_alloc. 