### PR TITLE
Simplify interface methods with Requires Expressions and later maybe Concepts

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install dependencies
       uses: awalsh128/cache-apt-pkgs-action@latest
       with:
-          packages: libeigen3-dev libarpack2-dev libgtest-dev libfmt-dev
+          packages: libeigen3-dev libarpack2-dev libgtest-dev libfmt-dev libcxxopts-dev
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/README.md
+++ b/README.md
@@ -72,13 +72,13 @@ Next, you may either embed the provided matrix with:
 	tapkee::with((method=Isomap,num_neighbors=15)).embedUsing(matrix);
 
 Or provide callbacks (kernel, distance and features) using any combination
-of the `withKernel(KernelCallback)`, `withDistance(DistanceCallback)` and
-`withFeatures(FeaturesCallback)` member functions:
+of the `with(KernelCallback)`, `with(DistanceCallback)` and
+`with(FeaturesCallback)` member functions:
 
 	tapkee::with((method=Isomap,num_neighbors=15))
-	       .withKernel(kernel_callback)
-	       .withDistance(distance_callback)
-	       .withFeatures(features_callback)
+	       .with(kernel_callback)
+	       .with(distance_callback)
+	       .with(features_callback)
 
 Once callbacks are initialized you may either embed data using an
 STL-compatible sequence of indices or objects (that supports the
@@ -94,11 +94,11 @@ As a summary - a few examples:
 	    .embedUsing(matrix);
 
 	TapkeeOutput output = with((method=Isomap,num_neighbors=15))
-	    .withDistance(distance_callback)
+	    .with(distance_callback)
 	    .embedUsing(indices);
 
 	TapkeeOutput output = with((method=Isomap,num_neighbors=15))
-	    .withDistance(distance_callback)
+	    .with(distance_callback)
 	    .embedRange(indices.begin(),indices.end());
 
 Minimal example
@@ -126,7 +126,7 @@ A minimal working example of a program that uses the library is:
 		MyDistanceCallback d;
 
 		TapkeeOutput output = tapkee::with((method=MultidimensionalScaling,target_dimension=1))
-		   .withDistance(d)
+		   .with(d)
 		   .embedUsing(indices);
 
 		cout << output.embedding.transpose() << endl;

--- a/examples/minimal/minimal.cpp
+++ b/examples/minimal/minimal.cpp
@@ -21,7 +21,7 @@ int main(int argc, const char **argv)
     MyDistanceCallback distance;
 
     TapkeeOutput output = with((method = MultidimensionalScaling, target_dimension = 1))
-                              .withDistance(distance)
+                              .with(distance)
                               .embedUsing(indices);
 
     cout << output.embedding.transpose() << endl;

--- a/examples/precomputed/precomputed.cpp
+++ b/examples/precomputed/precomputed.cpp
@@ -20,7 +20,7 @@ int main(int argc, const char **argv)
     precomputed_distance_callback distance(distances);
 
     TapkeeOutput output = with((method = MultidimensionalScaling, target_dimension = 1))
-                              .withDistance(distance)
+                              .with(distance)
                               .embedUsing(indices);
 
     cout << output.embedding.transpose() << endl;

--- a/examples/rna/rna.cpp
+++ b/examples/rna/rna.cpp
@@ -33,9 +33,9 @@ int main(int argc, const char **argv)
 
     MatchKernelCallback kernel;
 
-    TapkeeOutput result = .with((method = KernelLocallyLinearEmbedding, num_neighbors = 30))
-                              .withKernel(kernel)
-                              .embedUsing(rnas);
+    TapkeeOutput result = with((method = KernelLocallyLinearEmbedding, num_neighbors = 30))
+                         .with(kernel)
+                         .embedUsing(rnas);
 
     cout << result.embedding.transpose() << endl;
 

--- a/examples/rna/rna.md
+++ b/examples/rna/rna.md
@@ -3,4 +3,4 @@ In this example RNA sequencies are embedded using the match kernel
 RNA sequencies are supposed to be read from the file provided via a command line 
 argument (one sequence per line). As the Kernel Locally Linear Embedding algorithm 
 requires only a kernel callback we just pass only the kernel callback using
-the `withKernel` member function. 
+the `with` member function. 

--- a/include/tapkee/callbacks/dummy_callbacks.hpp
+++ b/include/tapkee/callbacks/dummy_callbacks.hpp
@@ -26,6 +26,7 @@ template <class Data> struct dummy_features_callback
 template <class Data> struct dummy_kernel_callback
 {
     typedef int dummy;
+    typedef Data ArgType;
     inline tapkee::ScalarType kernel(const Data&, const Data&) const
     {
         throw tapkee::unsupported_method_error("Dummy kernel callback is set");

--- a/include/tapkee/chain_interface.hpp
+++ b/include/tapkee/chain_interface.hpp
@@ -69,7 +69,8 @@ template <class KernelCallback, class DistanceCallback> class KernelAndDistanceI
      *        first argument.
      */
     template <class FeaturesCallback>
-    CallbacksInitializedState<KernelCallback, DistanceCallback, FeaturesCallback> withFeatures(
+        requires requires(FeaturesCallback callback) { callback.dimension(); }
+    CallbacksInitializedState<KernelCallback, DistanceCallback, FeaturesCallback> with(
         const FeaturesCallback& features) const
     {
         return CallbacksInitializedState<KernelCallback, DistanceCallback, FeaturesCallback>(parameters, kernel,
@@ -86,7 +87,7 @@ template <class KernelCallback, class DistanceCallback> class KernelAndDistanceI
     TapkeeOutput embedRange(RandomAccessIterator begin, RandomAccessIterator end) const
     {
         return (*this)
-            .withFeatures(dummy_features_callback<typename RandomAccessIterator::value_type>())
+            .with(dummy_features_callback<typename RandomAccessIterator::value_type>())
             .embedRange(begin, end);
     }
 
@@ -122,7 +123,9 @@ template <class KernelCallback, class FeaturesCallback> class KernelAndFeaturesI
      *        pointed by the first and the second arguments.
      */
     template <class DistanceCallback>
-    CallbacksInitializedState<KernelCallback, DistanceCallback, FeaturesCallback> withDistance(
+        requires requires(DistanceCallback callback, ScalarType a, ScalarType b) { callback.distance(a, b); } ||
+                 requires(DistanceCallback callback) { callback.distance_matrix; }
+    CallbacksInitializedState<KernelCallback, DistanceCallback, FeaturesCallback> with(
         const DistanceCallback& distance) const
     {
         return CallbacksInitializedState<KernelCallback, DistanceCallback, FeaturesCallback>(parameters, kernel,
@@ -139,7 +142,7 @@ template <class KernelCallback, class FeaturesCallback> class KernelAndFeaturesI
     TapkeeOutput embedRange(RandomAccessIterator begin, RandomAccessIterator end) const
     {
         return (*this)
-            .withDistance(dummy_distance_callback<typename RandomAccessIterator::value_type>())
+            .with(dummy_distance_callback<typename RandomAccessIterator::value_type>())
             .embedRange(begin, end);
     }
 
@@ -181,7 +184,10 @@ template <class DistanceCallback, class FeaturesCallback> class DistanceAndFeatu
      *        pointed by the first and the second arguments.
      */
     template <class KernelCallback>
-    CallbacksInitializedState<KernelCallback, DistanceCallback, FeaturesCallback> withKernel(
+        requires requires(KernelCallback callback, ScalarType a, ScalarType b) { callback.kernel(a, b); } ||
+                 requires(KernelCallback callback, const std::string& a, const std::string& b) { callback.kernel(a, b); } ||
+                 requires(KernelCallback callback) { callback.kernel_matrix; }
+    CallbacksInitializedState<KernelCallback, DistanceCallback, FeaturesCallback> with(
         const KernelCallback& kernel) const
     {
         return CallbacksInitializedState<KernelCallback, DistanceCallback, FeaturesCallback>(parameters, kernel,
@@ -198,7 +204,7 @@ template <class DistanceCallback, class FeaturesCallback> class DistanceAndFeatu
     TapkeeOutput embedRange(RandomAccessIterator begin, RandomAccessIterator end) const
     {
         return (*this)
-            .withKernel(dummy_kernel_callback<typename RandomAccessIterator::value_type>())
+            .with(dummy_kernel_callback<typename RandomAccessIterator::value_type>())
             .embedRange(begin, end);
     }
 
@@ -234,7 +240,9 @@ template <class KernelCallback> class KernelFirstInitializedState
      *        pointed by the first and the second arguments.
      */
     template <class DistanceCallback>
-    KernelAndDistanceInitializedState<KernelCallback, DistanceCallback> withDistance(
+        requires requires(DistanceCallback callback, ScalarType a, ScalarType b) { callback.distance(a, b); } ||
+                 requires(DistanceCallback callback) { callback.distance_matrix; }
+    KernelAndDistanceInitializedState<KernelCallback, DistanceCallback> with(
         const DistanceCallback& callback) const
     {
         return KernelAndDistanceInitializedState<KernelCallback, DistanceCallback>(parameters, kernel, callback);
@@ -248,7 +256,8 @@ template <class KernelCallback> class KernelFirstInitializedState
      *        first argument.
      */
     template <class FeaturesCallback>
-    KernelAndFeaturesInitializedState<KernelCallback, FeaturesCallback> withFeatures(
+        requires requires(FeaturesCallback callback) { callback.dimension(); }
+    KernelAndFeaturesInitializedState<KernelCallback, FeaturesCallback> with(
         const FeaturesCallback& callback) const
     {
         return KernelAndFeaturesInitializedState<KernelCallback, FeaturesCallback>(parameters, kernel, callback);
@@ -264,8 +273,8 @@ template <class KernelCallback> class KernelFirstInitializedState
     TapkeeOutput embedRange(RandomAccessIterator begin, RandomAccessIterator end) const
     {
         return (*this)
-            .withDistance(dummy_distance_callback<typename RandomAccessIterator::value_type>())
-            .withFeatures(dummy_features_callback<typename RandomAccessIterator::value_type>())
+            .with(dummy_distance_callback<typename RandomAccessIterator::value_type>())
+            .with(dummy_features_callback<typename RandomAccessIterator::value_type>())
             .embedRange(begin, end);
     }
 
@@ -300,7 +309,10 @@ template <class DistanceCallback> class DistanceFirstInitializedState
      *        pointed by the first and the second arguments.
      */
     template <class KernelCallback>
-    KernelAndDistanceInitializedState<KernelCallback, DistanceCallback> withKernel(const KernelCallback& callback) const
+        requires requires(KernelCallback callback, ScalarType a, ScalarType b) { callback.kernel(a, b); } ||
+                 requires(KernelCallback callback, const std::string& a, const std::string& b) { callback.kernel(a, b); } ||
+                 requires(KernelCallback callback) { callback.kernel_matrix; }
+    KernelAndDistanceInitializedState<KernelCallback, DistanceCallback> with(const KernelCallback& callback) const
     {
         return KernelAndDistanceInitializedState<KernelCallback, DistanceCallback>(parameters, callback, distance);
     }
@@ -313,7 +325,8 @@ template <class DistanceCallback> class DistanceFirstInitializedState
      *        first argument.
      */
     template <class FeaturesCallback>
-    DistanceAndFeaturesInitializedState<DistanceCallback, FeaturesCallback> withFeatures(
+        requires requires(FeaturesCallback callback) { callback.dimension(); }
+    DistanceAndFeaturesInitializedState<DistanceCallback, FeaturesCallback> with(
         const FeaturesCallback& callback) const
     {
         return DistanceAndFeaturesInitializedState<DistanceCallback, FeaturesCallback>(parameters, distance, callback);
@@ -329,8 +342,8 @@ template <class DistanceCallback> class DistanceFirstInitializedState
     TapkeeOutput embedRange(RandomAccessIterator begin, RandomAccessIterator end) const
     {
         return (*this)
-            .withKernel(dummy_kernel_callback<typename RandomAccessIterator::value_type>())
-            .withFeatures(dummy_features_callback<typename RandomAccessIterator::value_type>())
+            .with(dummy_kernel_callback<typename RandomAccessIterator::value_type>())
+            .with(dummy_features_callback<typename RandomAccessIterator::value_type>())
             .embedRange(begin, end);
     }
 
@@ -365,7 +378,10 @@ template <class FeaturesCallback> class FeaturesFirstInitializedState
      *        pointed by the first and the second arguments.
      */
     template <class KernelCallback>
-    KernelAndFeaturesInitializedState<KernelCallback, FeaturesCallback> withKernel(const KernelCallback& callback) const
+        requires requires(KernelCallback callback, ScalarType a, ScalarType b) { callback.kernel(a, b); } ||
+                 requires(KernelCallback callback, const std::string& a, const std::string& b) { callback.kernel(a, b); } ||
+                 requires(KernelCallback callback) { callback.kernel_matrix; }
+    KernelAndFeaturesInitializedState<KernelCallback, FeaturesCallback> with(const KernelCallback& callback) const
     {
         return KernelAndFeaturesInitializedState<KernelCallback, FeaturesCallback>(parameters, callback, features);
     }
@@ -378,7 +394,9 @@ template <class FeaturesCallback> class FeaturesFirstInitializedState
      *        pointed by the first and the second arguments.
      */
     template <class DistanceCallback>
-    DistanceAndFeaturesInitializedState<DistanceCallback, FeaturesCallback> withDistance(
+        requires requires(DistanceCallback callback, ScalarType a, ScalarType b) { callback.distance(a, b); } ||
+                 requires(DistanceCallback callback) { callback.distance_matrix; }
+    DistanceAndFeaturesInitializedState<DistanceCallback, FeaturesCallback> with(
         const DistanceCallback& callback) const
     {
         return DistanceAndFeaturesInitializedState<DistanceCallback, FeaturesCallback>(parameters, callback, features);
@@ -394,8 +412,8 @@ template <class FeaturesCallback> class FeaturesFirstInitializedState
     TapkeeOutput embedRange(RandomAccessIterator begin, RandomAccessIterator end) const
     {
         return (*this)
-            .withKernel(dummy_kernel_callback<typename RandomAccessIterator::value_type>())
-            .withDistance(dummy_distance_callback<typename RandomAccessIterator::value_type>())
+            .with(dummy_kernel_callback<typename RandomAccessIterator::value_type>())
+            .with(dummy_distance_callback<typename RandomAccessIterator::value_type>())
             .embedRange(begin, end);
     }
 
@@ -431,7 +449,10 @@ class ParametersInitializedState
      *        pointed by the first and the second arguments.
      */
     template <class KernelCallback>
-    KernelFirstInitializedState<KernelCallback> withKernel(const KernelCallback& callback) const
+        requires requires(KernelCallback callback, ScalarType a, ScalarType b) { callback.kernel(a, b); } ||
+                 requires(KernelCallback callback, const std::string& a, const std::string& b) { callback.kernel(a, b); } ||
+                 requires(KernelCallback callback) { callback.kernel_matrix; }
+    KernelFirstInitializedState<KernelCallback> with(const KernelCallback& callback) const
     {
         return KernelFirstInitializedState<KernelCallback>(parameters, callback);
     }
@@ -444,7 +465,9 @@ class ParametersInitializedState
      *        pointed by the first and the second arguments.
      */
     template <class DistanceCallback>
-    DistanceFirstInitializedState<DistanceCallback> withDistance(const DistanceCallback& callback) const
+        requires requires(DistanceCallback callback, ScalarType a, ScalarType b) { callback.distance(a, b); } ||
+                 requires(DistanceCallback callback) { callback.distance_matrix; }
+    DistanceFirstInitializedState<DistanceCallback> with(const DistanceCallback& callback) const
     {
         return DistanceFirstInitializedState<DistanceCallback>(parameters, callback);
     }
@@ -457,7 +480,8 @@ class ParametersInitializedState
      *        first argument.
      */
     template <class FeaturesCallback>
-    FeaturesFirstInitializedState<FeaturesCallback> withFeatures(const FeaturesCallback& callback) const
+        requires requires(FeaturesCallback callback) { callback.dimension(); }
+    FeaturesFirstInitializedState<FeaturesCallback> with(const FeaturesCallback& callback) const
     {
         return FeaturesFirstInitializedState<FeaturesCallback>(parameters, callback);
     }
@@ -488,9 +512,9 @@ class ParametersInitializedState
  *
  * In the chain this method's call is followed by any of
  * @ref tapkee_internal::ParametersInitializedState::embedUsing
- * @ref tapkee_internal::ParametersInitializedState::withKernel
- * @ref tapkee_internal::ParametersInitializedState::withDistance
- * @ref tapkee_internal::ParametersInitializedState::withFeatures
+ * @ref tapkee_internal::ParametersInitializedState::with(const KernelCallback&)
+ * @ref tapkee_internal::ParametersInitializedState::with(const DistanceCallback&)
+ * @ref tapkee_internal::ParametersInitializedState::with(const FeaturesCallback&)
  *
  * @param parameters a set of parameters formed by keywords assigned to values
  */

--- a/include/tapkee/chain_interface.hpp
+++ b/include/tapkee/chain_interface.hpp
@@ -241,7 +241,10 @@ template <class KernelCallback> class KernelFirstInitializedState
      */
     template <class DistanceCallback>
         requires requires(DistanceCallback callback, ScalarType a, ScalarType b) { callback.distance(a, b); } ||
-                 requires(DistanceCallback callback) { callback.distance_matrix; }
+                 requires(DistanceCallback callback) { callback.distance_matrix; } ||
+                 requires(DistanceCallback callback,
+                          const typename DistanceCallback::ArgType& a,
+                          const typename DistanceCallback::ArgType& b) { callback.distance(a, b); }
     KernelAndDistanceInitializedState<KernelCallback, DistanceCallback> with(
         const DistanceCallback& callback) const
     {

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -513,9 +513,9 @@ int run(int argc, const char **argv)
         tapkee::eigen_features_callback fcb(input_data);
 
         output = tapkee::with(parameters)
-                    .withKernel(kcb)
-                    .withDistance(dcb)
-                    .withFeatures(fcb)
+                    .with(kcb)
+                    .with(dcb)
+                    .with(fcb)
                     .embedRange(indices.begin(), indices.end());
     }
     else

--- a/test/unit/interface.cpp
+++ b/test/unit/interface.cpp
@@ -21,81 +21,81 @@ TEST(Interface, ChainInterfaceOrder)
     TapkeeOutput output;
 
     ASSERT_NO_THROW(output = tapkee::with((method = MultidimensionalScaling))
-                                 .withKernel(kcb)
-                                 .withFeatures(fcb)
-                                 .withDistance(dcb)
+                                 .with(kcb)
+                                 .with(fcb)
+                                 .with(dcb)
                                  .embedRange(indices.begin(), indices.end()));
 
     ASSERT_NO_THROW(output = tapkee::with((method = MultidimensionalScaling))
-                                 .withKernel(kcb)
-                                 .withDistance(dcb)
-                                 .withFeatures(fcb)
+                                 .with(kcb)
+                                 .with(dcb)
+                                 .with(fcb)
                                  .embedRange(indices.begin(), indices.end()));
 
     ASSERT_NO_THROW(output = tapkee::with((method = KernelPrincipalComponentAnalysis))
-                                 .withDistance(dcb)
-                                 .withKernel(kcb)
-                                 .withFeatures(fcb)
+                                 .with(dcb)
+                                 .with(kcb)
+                                 .with(fcb)
                                  .embedRange(indices.begin(), indices.end()));
 
     ASSERT_NO_THROW(output = tapkee::with((method = PassThru))
-                                 .withDistance(dcb)
-                                 .withFeatures(fcb)
-                                 .withKernel(kcb)
+                                 .with(dcb)
+                                 .with(fcb)
+                                 .with(kcb)
                                  .embedRange(indices.begin(), indices.end()));
 
     ASSERT_NO_THROW(output = tapkee::with((method = MultidimensionalScaling))
-                                 .withFeatures(fcb)
-                                 .withDistance(dcb)
-                                 .withKernel(kcb)
+                                 .with(fcb)
+                                 .with(dcb)
+                                 .with(kcb)
                                  .embedRange(indices.begin(), indices.end()));
 
     ASSERT_NO_THROW(output = tapkee::with((method = MultidimensionalScaling))
-                                 .withFeatures(fcb)
-                                 .withKernel(kcb)
-                                 .withDistance(dcb)
+                                 .with(fcb)
+                                 .with(kcb)
+                                 .with(dcb)
                                  .embedRange(indices.begin(), indices.end()));
 
     ASSERT_NO_THROW(output = tapkee::with((method = PassThru))
-                                 .withFeatures(fcb)
-                                 .withKernel(kcb)
+                                 .with(fcb)
+                                 .with(kcb)
                                  .embedRange(indices.begin(), indices.end()));
 
     ASSERT_NO_THROW(output = tapkee::with((method = PassThru))
-                                 .withFeatures(fcb)
-                                 .withDistance(dcb)
+                                 .with(fcb)
+                                 .with(dcb)
                                  .embedRange(indices.begin(), indices.end()));
 
     ASSERT_NO_THROW(output = tapkee::with((method = KernelPrincipalComponentAnalysis))
-                                 .withKernel(kcb)
-                                 .withDistance(dcb)
+                                 .with(kcb)
+                                 .with(dcb)
                                  .embedRange(indices.begin(), indices.end()));
 
     ASSERT_NO_THROW(output = tapkee::with((method = KernelPrincipalComponentAnalysis))
-                                 .withKernel(kcb)
-                                 .withFeatures(fcb)
+                                 .with(kcb)
+                                 .with(fcb)
                                  .embedRange(indices.begin(), indices.end()));
 
     ASSERT_NO_THROW(output = tapkee::with((method = MultidimensionalScaling))
-                                 .withDistance(dcb)
-                                 .withFeatures(fcb)
+                                 .with(dcb)
+                                 .with(fcb)
                                  .embedRange(indices.begin(), indices.end()));
 
     ASSERT_NO_THROW(output = tapkee::with((method = MultidimensionalScaling))
-                                 .withDistance(dcb)
-                                 .withKernel(kcb)
+                                 .with(dcb)
+                                 .with(kcb)
                                  .embedRange(indices.begin(), indices.end()));
 
     ASSERT_NO_THROW(output = tapkee::with((method = KernelPrincipalComponentAnalysis))
-                                 .withKernel(kcb)
+                                 .with(kcb)
                                  .embedRange(indices.begin(), indices.end()));
 
     ASSERT_NO_THROW(output = tapkee::with((method = MultidimensionalScaling))
-                                 .withDistance(dcb)
+                                 .with(dcb)
                                  .embedRange(indices.begin(), indices.end()));
 
     ASSERT_NO_THROW(output = tapkee::with((method = PassThru))
-                                 .withFeatures(fcb)
+                                 .with(fcb)
                                  .embedRange(indices.begin(), indices.end()));
 }
 


### PR DESCRIPTION
Yesterday, we started with going from 

```cpp
  tapkee::initialize().withParameters((method=...,num_neighbors=...))
````
to
```cpp
  tapkee::with((method=...,))
```

For the distance, kernel, and/or features there are

```cpp
  tapkee::with(...).withKernel(kernel_callback)
                   .withDistance(distance_callback)
                   .withFeatures(features_callback)
```

which, yesterday afternoon, I thought could be nice to simplify since in e.g. 'withKernel(kernel_callback)' already from the kernel_callback's type it should be inferable that the 'with' is for a kernel.

From how to implement it, I got excited since I think requires/concepts are the good tool for this and I have never used them.

I think the result could look like

```cpp
  tapkee::with((method=...,...).with(kernel_callback).with(distance_callback)
```

or perhaps

```cpp
  tapkee::with((method=...,num_neighbors=...),
               kernel_callback,
               distance_callback)
```

(the latter may be quirky to have the kwargs betweeen parentheses and the others no, but I personally think it is not an issue and looks nice).

I am using Mateus Pusz library as a reference for the syntax, for example:
https://github.com/mpusz/mp-units/blob/602a60999547ed13134232b54f041bfac6ccc35b/src/core/include/mp-units/math.h#L227

I started experimenting yesterday night for about an hour and got this far.
I think the requires clauses are large enough to be worth their own concepts (e.g. DistanceCallback, KernelCallback, FeaturesCallback or maybe just even Distance, Kernel, and Features concepts and the *Callbacks would be the names for the template types complying to their respective concept).
The library could be built and the unit tests run with PASS. I think there's still problem with rna example. But in any case, this I don't think is close to good yet, just the experimental kickoff.