### PR TITLE
Sync version macros + add release checklist skill

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: release
+description: Use when preparing to cut a new Tapkee release (bumping the version, checking a release is ready to tag). Lists every place the version number and related metadata must be updated, in sync, before pushing a `vX.Y.Z` tag.
+---
+
+# Cutting a Tapkee release
+
+Tapkee has no single source of truth for its version — it is duplicated across a
+few files that must all be bumped together before tagging. This skill is a
+checklist, not an automation: read the current state of each file, report
+what needs to change for the target version, and only edit after confirming
+the target version with the user.
+
+## 1. Determine the target version
+
+- Read the current version from `packages/python/pyproject.toml` (`version = "..."`).
+- Ask the user for the target version if it isn't already clear from the
+  conversation (patch/minor/major bump). Don't guess silently — a wrong bump
+  here is annoying to unwind across three files plus a git tag.
+
+## 2. Files that must be updated to the new version
+
+All of these must match `X.Y.Z` of the target release:
+
+- `packages/python/pyproject.toml` — `version = "X.Y.Z"`
+- `packages/r/DESCRIPTION` — `Version: X.Y.Z`
+- `include/tapkee/defines.hpp` — `TAPKEE_MAJOR_VERSION` and
+  `TAPKEE_MINOR_VERSION` (map to `Y` and `Z`). Leave `TAPKEE_WORLD_VERSION`
+  alone unless this is a deliberate breaking/epoch bump — it has stayed `1`
+  since the project's origin.
+
+Grep for the current version string across the repo to catch anything missed
+(README badges/examples, `packages/r/DESCRIPTION`, changelog, etc.):
+
+```bash
+grep -rn "<old-version>" --include="*.toml" --include="DESCRIPTION" --include="*.hpp" --include="*.md" . \
+  | grep -vE "build/|\.venv|venv/|dist/|tapkee\.Rcheck|__pycache__"
+```
+
+## 3. Sanity checks before tagging
+
+- `git status` — make sure the working tree only contains the intended
+  version-bump changes. Untracked build cruft (`tapkee.Rcheck/`,
+  `tapkee_*.tar.gz`, `examples/__pycache__/`) should NOT be committed —
+  it's stale local build output, not release material.
+- Confirm README.md doesn't have stale links pointing at old file paths or
+  the `master` branch (the default branch is `main`) — check with:
+  `grep -n "master\b" README.md`
+- No `CHANGELOG.md` is currently tracked in this repo — don't invent one
+  unless the user asks for it.
+
+## 4. Tag and trigger the release
+
+`.github/workflows/release.yml` triggers on push of a `v*` tag and builds
+CLI binaries, the sdist, wheels, and publishes to PyPI + creates the GitHub
+release. After the version-bump commit is merged to `main`:
+
+```bash
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```
+
+Confirm with the user before pushing the tag — it's a one-way trigger for a
+real publish (PyPI + GitHub release), not a reversible local action.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,64 +1,73 @@
 ---
 name: release
-description: Use when preparing to cut a new Tapkee release (bumping the version, checking a release is ready to tag). Lists every place the version number and related metadata must be updated, in sync, before pushing a `vX.Y.Z` tag.
+description: Use this skill before you cut a new Tapkee release. This skill helps you set the version number and check that the release is ready. This skill lists all files that must show the new version number before you push a `vX.Y.Z` tag.
 ---
 
-# Cutting a Tapkee release
+# How to cut a Tapkee release
 
-Tapkee has no single source of truth for its version — it is duplicated across a
-few files that must all be bumped together before tagging. This skill is a
-checklist, not an automation: read the current state of each file, report
-what needs to change for the target version, and only edit after confirming
-the target version with the user.
+Tapkee does not have one single source for the version number. The version
+number is in more than one file. You must update all these files together
+before you create the release tag.
 
-## 1. Determine the target version
+This skill gives you a checklist. This skill does not update the files for
+you. Read the current version number in each file. Tell the user what you
+must change for the target version. Do not edit a file before the user
+confirms the target version.
 
-- Read the current version from `packages/python/pyproject.toml` (`version = "..."`).
-- Ask the user for the target version if it isn't already clear from the
-  conversation (patch/minor/major bump). Don't guess silently — a wrong bump
-  here is annoying to unwind across three files plus a git tag.
+## Step 1: Find the target version number
 
-## 2. Files that must be updated to the new version
+- Read the current version number in `packages/python/pyproject.toml`. Find
+  the line `version = "..."`.
+- Ask the user for the target version number if the user has not given it.
+  Do not guess the version number. A wrong version number is difficult to
+  correct. You must correct it in three files and in one git tag.
 
-All of these must match `X.Y.Z` of the target release:
+## Step 2: Set the new version number in these files
 
-- `packages/python/pyproject.toml` — `version = "X.Y.Z"`
-- `packages/r/DESCRIPTION` — `Version: X.Y.Z`
-- `include/tapkee/defines.hpp` — `TAPKEE_MAJOR_VERSION` and
-  `TAPKEE_MINOR_VERSION` (map to `Y` and `Z`). Leave `TAPKEE_WORLD_VERSION`
-  alone unless this is a deliberate breaking/epoch bump — it has stayed `1`
-  since the project's origin.
+All these files must show the same version number, `X.Y.Z`:
 
-Grep for the current version string across the repo to catch anything missed
-(README badges/examples, `packages/r/DESCRIPTION`, changelog, etc.):
+- `packages/python/pyproject.toml`. Set `version = "X.Y.Z"`.
+- `packages/r/DESCRIPTION`. Set `Version: X.Y.Z`.
+- `include/tapkee/defines.hpp`. Set `TAPKEE_MAJOR_VERSION` to `Y`. Set
+  `TAPKEE_MINOR_VERSION` to `Z`. Do not change `TAPKEE_WORLD_VERSION`. Change
+  this macro only for a breaking change or a new epoch. This macro has
+  stayed at `1` since the start of the project.
+
+Search the repository for the old version number. This search can find
+other files with the old version number, for example README.md:
 
 ```bash
 grep -rn "<old-version>" --include="*.toml" --include="DESCRIPTION" --include="*.hpp" --include="*.md" . \
   | grep -vE "build/|\.venv|venv/|dist/|tapkee\.Rcheck|__pycache__"
 ```
 
-## 3. Sanity checks before tagging
+## Step 3: Check the repository before you create the tag
 
-- `git status` — make sure the working tree only contains the intended
-  version-bump changes. Untracked build cruft (`tapkee.Rcheck/`,
-  `tapkee_*.tar.gz`, `examples/__pycache__/`) should NOT be committed —
-  it's stale local build output, not release material.
-- Confirm README.md doesn't have stale links pointing at old file paths or
-  the `master` branch (the default branch is `main`) — check with:
-  `grep -n "master\b" README.md`
-- No `CHANGELOG.md` is currently tracked in this repo — don't invent one
-  unless the user asks for it.
+- Run `git status`. Check that the change set has only the version update.
+  Do not commit build output, for example `tapkee.Rcheck/`,
+  `tapkee_*.tar.gz`, or `examples/__pycache__/`. This build output is old
+  local data. This build output is not part of the release.
+- Check README.md for old links. An old link can point to an old file path.
+  An old link can point to the `master` branch. The default branch is now
+  `main`. Use this command: `grep -n "master\b" README.md`
+- This repository does not have a `CHANGELOG.md` file. Do not create this
+  file unless the user asks for it.
 
-## 4. Tag and trigger the release
+## Step 4: Create the tag and start the release
 
-`.github/workflows/release.yml` triggers on push of a `v*` tag and builds
-CLI binaries, the sdist, wheels, and publishes to PyPI + creates the GitHub
-release. After the version-bump commit is merged to `main`:
+The file `.github/workflows/release.yml` starts the release process. This
+process starts when you push a tag with the format `v*`. The process builds
+the CLI binaries. The process builds the sdist package. The process builds
+the wheels. The process publishes the package to PyPI. The process creates
+the GitHub release.
+
+Do this after the version-update commit reaches the `main` branch:
 
 ```bash
 git tag vX.Y.Z
 git push origin vX.Y.Z
 ```
 
-Confirm with the user before pushing the tag — it's a one-way trigger for a
-real publish (PyPI + GitHub release), not a reversible local action.
+Ask the user before you push the tag. This action starts a real publish
+process. This action is not reversible. The action publishes the package to
+PyPI. The action creates a GitHub release.

--- a/include/tapkee/defines.hpp
+++ b/include/tapkee/defines.hpp
@@ -12,8 +12,8 @@
 #include <string>
 
 #define TAPKEE_WORLD_VERSION 1
-#define TAPKEE_MAJOR_VERSION 0
-#define TAPKEE_MINOR_VERSION 2
+#define TAPKEE_MAJOR_VERSION 3
+#define TAPKEE_MINOR_VERSION 4
 
 /* Tapkee includes */
 #include <tapkee/defines/eigen3.hpp>


### PR DESCRIPTION
## Summary
- `TAPKEE_MAJOR_VERSION`/`TAPKEE_MINOR_VERSION` in `include/tapkee/defines.hpp` still said 1.0.2, three releases behind the actual package version (1.3.4 per `packages/python/pyproject.toml` and `packages/r/DESCRIPTION`)
- Added `.claude/skills/release/SKILL.md`, a `/release` checklist skill: version is duplicated across `pyproject.toml`, `DESCRIPTION`, and `defines.hpp` with no single source of truth, so it documents every place to update in sync (plus a pre-tag sanity check and the tag/push step that triggers `release.yml`)

## Test plan
- [x] Header-only, one-line constant change — no build/behavior impact
- [x] Skill file is docs-only, not consumed by the build