### PR TITLE
Drop stale devcontainer config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,0 @@
-{
-  "image": "mcr.microsoft.com/devcontainers/universal:2",
-  "features": {
-    "ghcr.io/devcontainers/features/conda:1": {}
-  }
-}


### PR DESCRIPTION
## Summary
- `.devcontainer/devcontainer.json` was last touched 2023-06-26 and hasn't kept up with the project: it predates the C++23/CMake 3.24 requirement, the Python (nanobind) and R (Rcpp) packages, and the Eigen 3.4+ bump
- It never installed Eigen/fmt/cxxopts/ARPACK (see `linux.yml` for the actual dependency list), so `cmake` configure fails inside it as shipped — not a working baseline worth patching incrementally, so removing it rather than updating it

## Test plan
- [x] File removal only, no build/CI impact