### PR TITLE
ci: switch macOS wheel runner to macos-latest

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -48,7 +48,7 @@ jobs:
             os: ubuntu-latest
             arch: x86_64
           - name: macOS
-            os: macos-26-arm64
+            os: macos-latest
             arch: arm64
             macos_target: "26.0"
           - name: Windows


### PR DESCRIPTION
## Summary
- `macos-26-arm64` was pinned in the last commit but the runner never picked up jobs — CI waited indefinitely.
- macOS 26 is now GA and `macos-latest` points to it, so switch back to `macos-latest` for the macOS wheel build.

## Test plan
- [x] Confirm the `Wheels / macOS` job actually gets picked up by a runner (not stuck queued)
- [x] Confirm the macOS wheel build completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)