### PR TITLE
Replace std::rand with <random> engine and distributions

### DIFF
--- a/include/tapkee/defines/random.hpp
+++ b/include/tapkee/defines/random.hpp
@@ -5,25 +5,36 @@
 #pragma once
 
 #include <algorithm>
-#include <cstdlib>
 #include <limits>
 #include <random>
 
 namespace tapkee
 {
 
+inline std::mt19937_64& random_generator()
+{
+    static thread_local std::mt19937_64 generator(std::random_device{}());
+    return generator;
+}
+
 inline IndexType uniform_random_index()
 {
 #ifdef CUSTOM_UNIFORM_RANDOM_INDEX_FUNCTION
     return CUSTOM_UNIFORM_RANDOM_INDEX_FUNCTION % std::numeric_limits<IndexType>::max();
 #else
-    return std::rand();
+    std::uniform_int_distribution<IndexType> distribution(0, std::numeric_limits<IndexType>::max() - 1);
+    return distribution(random_generator());
 #endif
 }
 
 inline IndexType uniform_random_index_bounded(IndexType upper)
 {
+#ifdef CUSTOM_UNIFORM_RANDOM_INDEX_FUNCTION
     return uniform_random_index() % upper;
+#else
+    std::uniform_int_distribution<IndexType> distribution(0, upper - 1);
+    return distribution(random_generator());
+#endif
 }
 
 inline ScalarType uniform_random()
@@ -31,7 +42,8 @@ inline ScalarType uniform_random()
 #ifdef CUSTOM_UNIFORM_RANDOM_FUNCTION
     return CUSTOM_UNIFORM_RANDOM_FUNCTION;
 #else
-    return std::rand() / ((double)RAND_MAX + 1);
+    std::uniform_real_distribution<ScalarType> distribution(0.0, 1.0);
+    return distribution(random_generator());
 #endif
 }
 
@@ -40,24 +52,14 @@ inline ScalarType gaussian_random()
 #ifdef CUSTOM_GAUSSIAN_RANDOM_FUNCTION
     return CUSTOM_GAUSSIAN_RANDOM_FUNCTION;
 #else
-    ScalarType x, y, radius;
-    do
-    {
-        x = 2 * (std::rand() / ((double)RAND_MAX + 1)) - 1;
-        y = 2 * (std::rand() / ((double)RAND_MAX + 1)) - 1;
-        radius = (x * x) + (y * y);
-    } while ((radius >= 1.0) || (radius == 0.0));
-    radius = std::sqrt(-2 * std::log(radius) / radius);
-    x *= radius;
-    return x;
+    std::normal_distribution<ScalarType> distribution(0.0, 1.0);
+    return distribution(random_generator());
 #endif
 }
 
 template <class RAI> inline void random_shuffle(RAI first, RAI last)
 {
-    std::random_device rng;
-    std::mt19937 urng(rng());
-    std::shuffle(first, last, urng);
+    std::shuffle(first, last, random_generator());
 }
 
 } // namespace tapkee

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -155,8 +155,6 @@ static const char* PRECOMPUTE_DESCRIPTION = "Whether distance and kernel matrice
 
 int run(int argc, const char **argv)
 {
-    srand(static_cast<unsigned int>(time(NULL)));
-
     cxxopts::Options options("tapkee", "Tapkee: a tool for dimensionality reduction.");
 
     using namespace std::string_literals;


### PR DESCRIPTION
## What changed

All four RNG helpers in `include/tapkee/defines/random.hpp` now draw from a shared `thread_local std::mt19937_64` engine seeded from `std::random_device`:

- `uniform_random_index_bounded` uses `uniform_int_distribution` over `[0, upper)`, removing the modulo bias of `rand() % upper`
- `uniform_random` uses `uniform_real_distribution` instead of dividing by `RAND_MAX`
- `gaussian_random` uses `std::normal_distribution` instead of the hand-rolled Marsaglia polar loop
- `random_shuffle` reuses the shared engine instead of constructing a fresh `std::random_device` + `mt19937` on every call

The CLI's `srand(time(NULL))` is dropped since nothing reads C rand state anymore.

## Why

`std::rand` is shared mutable state across threads, low-quality, and a recurring CRAN compiled-code complaint surface. The per-call `random_device` construction in `random_shuffle` was also wasteful. Thread safety and distribution quality both improve.

## Notes for review

- The `CUSTOM_UNIFORM_RANDOM_INDEX_FUNCTION` / `CUSTOM_UNIFORM_RANDOM_FUNCTION` / `CUSTOM_GAUSSIAN_RANDOM_FUNCTION` macro overrides used by the R package are preserved and verified with a standalone compile: all three route correctly, including the bounded-index `% upper` fallback.
- Verified by CLI runs of all three RNG-dependent paths: random projection (`gaussian_random`), SPE (`uniform_random` + `random_shuffle`), and randomized eigendecomposition. Full build and all 5 ctest suites pass.
- Reproducibility note: results were never seed-reproducible (the CLI seeded with wall-clock time). If a `--seed` flag is ever wanted, the new `random_generator()` accessor makes it a two-line addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)